### PR TITLE
hide header on macOS, thanks to @henrikdahl, fix #1

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,3 +17,10 @@ exports.decorateConfig = (config) => {
     `
   });
 }
+
+// Hide window controls on macOS
+exports.decorateBrowserOptions = defaults => Object.assign({}, defaults, {
+  titleBarStyle: '',
+  transparent: true,
+  frame: false
+})

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperminimal",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Removes the window header from Hyper terminal for more space and less distraction.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Based on the comment by @henrikdahl at https://github.com/jancborchardt/hyperminimal/issues/1#issuecomment-267751125 – thank you! :tada: 

But since I don’t have macOS myself I can’t test and I’m not sure which additional styles are needed. Please test and let me know how it looks @hedefalk. (And maybe @eppfel @xMartin do you use Hyper? ;)