### PR TITLE
platform check, css for macos

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,49 +1,46 @@
 exports.decorateConfig = (config) => {
-    if (process.platform === 'win32') {
-        return Object.assign({}, config, {
-            css: `
-                ${config.css || ''}
-                .header_windowHeader {
-                    display: none;
-                }
-                .tabs_nav {
-                    top: 0;
-                }
-                .terms_terms {
-                    margin-top: 0;
-                }
-                .terms_termsShifted {
-                    margin-top: 34px;
-                }
-            `
-        });
+  var defaultCSS = `
+    .header_header {
+      top: 0;
+      right: 0;
+      left: 0;
     }
-    if (process.platform === 'darwin') {
-        return Object.assign({}, config, {
-            css: `
-                ${config.css || ''}
-                .header_header {
-                    top: 0;
-                    right: 0;
-                    left: 0;
-                }
-                .tabs_borderShim {
-                    display: none;
-                }
-                .tabs_title {
-                    display: none;
-                }
-                .tabs_list {
-                    margin-left: 0;
-                }
-            `
-        });
+    .tabs_borderShim {
+      display: none;
     }
+    .tabs_title {
+      display: none;
+    }
+    .tabs_list {
+      margin-left: 0;
+    }
+  `
+  var windowsCSS = `
+    .header_windowHeader {
+      display: none;
+    }
+    .tabs_nav {
+      top: 0;
+    }
+    .terms_terms {
+      margin-top: 0;
+    }
+    .terms_termsShifted {
+      margin-top: 34px;
+    }
+  `
+
+  return Object.assign({}, config, {
+  css: `
+      ${config.css || ''}
+      ${process.platform === 'win32' ? windowsCSS : defaultCSS}
+    `
+  });
 }
 
 // Hide window controls on macOS
 exports.decorateBrowserOptions = defaults => Object.assign({}, defaults, {
-    titleBarStyle: '',
-    transparent: true,
-    frame: false
+  titleBarStyle: '',
+  transparent: true,
+  frame: false
 })

--- a/index.js
+++ b/index.js
@@ -1,19 +1,49 @@
 exports.decorateConfig = (config) => {
-  return Object.assign({}, config, {
-    css: `
-      ${config.css || ''}
-      .header_windowHeader {
-        display: none;
-      }
-      .tabs_nav {
-        top: 0;
-      }
-      .terms_terms {
-        margin-top: 0;
-      }
-      .terms_termsShifted {
-        margin-top: 34px;
-      }
-    `
-  });
+    if (process.platform === 'win32') {
+        return Object.assign({}, config, {
+            css: `
+                ${config.css || ''}
+                .header_windowHeader {
+                    display: none;
+                }
+                .tabs_nav {
+                    top: 0;
+                }
+                .terms_terms {
+                    margin-top: 0;
+                }
+                .terms_termsShifted {
+                    margin-top: 34px;
+                }
+            `
+        });
+    }
+    if (process.platform === 'darwin') {
+        return Object.assign({}, config, {
+            css: `
+                ${config.css || ''}
+                .header_header {
+                    top: 0;
+                    right: 0;
+                    left: 0;
+                }
+                .tabs_borderShim {
+                    display: none;
+                }
+                .tabs_title {
+                    display: none;
+                }
+                .tabs_list {
+                    margin-left: 0;
+                }
+            `
+        });
+    }
 }
+
+// Hide window controls on macOS
+exports.decorateBrowserOptions = defaults => Object.assign({}, defaults, {
+    titleBarStyle: '',
+    transparent: true,
+    frame: false
+})


### PR DESCRIPTION
If you want it to toggle the margin on `.terms_terms` between title and tabs you'll have to add JS to support it.

![skarmavbild 2016-12-20 kl 22 59 50](https://cloud.githubusercontent.com/assets/1430576/21369614/0dd81868-c708-11e6-9841-176253e6e943.png)

![skarmavbild 2016-12-20 kl 22 59 54](https://cloud.githubusercontent.com/assets/1430576/21369618/11908f3a-c708-11e6-9fff-f4b9b28ee013.png)