### PR TITLE
Removes the redundant space when there is only one tab

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,3 +44,19 @@ exports.decorateBrowserOptions = defaults => Object.assign({}, defaults, {
   transparent: true,
   frame: false
 })
+
+// Removes the redundant space on mac if there is only one tab
+exports.getTabsProps = (parentProps, props) => {
+  if (process.platform === 'darwin') {
+    var classTermsList = document.getElementsByClassName('terms_terms')
+    if (classTermsList.length > 0) {
+      var classTerm = classTermsList[0]
+      if (props.tabs.length <= 1) {
+        classTerm.setAttribute("style", "margin-top: 0")
+      } else {
+        classTerm.setAttribute("style", "")
+      }
+    }
+  }
+  return Object.assign({}, parentProps, props)
+}

--- a/index.js
+++ b/index.js
@@ -50,11 +50,11 @@ exports.getTabsProps = (parentProps, props) => {
   if (process.platform === 'darwin') {
     var classTermsList = document.getElementsByClassName('terms_terms')
     if (classTermsList.length > 0) {
-      var classTerm = classTermsList[0]
+      var classTerms = classTermsList[0]
       if (props.tabs.length <= 1) {
-        classTerm.setAttribute("style", "margin-top: 0")
+        classTerms.setAttribute("style", "margin-top: 0")
       } else {
-        classTerm.setAttribute("style", "")
+        classTerms.setAttribute("style", "")
       }
     }
   }

--- a/index.js
+++ b/index.js
@@ -52,9 +52,9 @@ exports.getTabsProps = (parentProps, props) => {
     if (classTermsList.length > 0) {
       var classTerms = classTermsList[0]
       if (props.tabs.length <= 1) {
-        classTerms.setAttribute("style", "margin-top: 0")
+        classTerms.setAttribute('style', 'margin-top: 0')
       } else {
-        classTerms.setAttribute("style", "")
+        classTerms.setAttribute('style', '')
       }
     }
   }


### PR DESCRIPTION
It checks if there is only one tab open and if there is it will remove the redundant space.
Single tab
<img width="636" alt="screen shot 2016-12-22 at 21 02 52" src="https://cloud.githubusercontent.com/assets/17733641/21438609/35950270-c88a-11e6-81da-49574abd54a6.png">
With multiple tabs
<img width="633" alt="screen shot 2016-12-22 at 21 01 44" src="https://cloud.githubusercontent.com/assets/17733641/21438605/335c9784-c88a-11e6-9268-ae2c4e0b31d9.png">