### PR TITLE
Tabs list design details

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 exports.decorateConfig = (config) => {
-  var macosCSS = `
+  const macosCSS = `
     .header_header {
       top: 0;
       right: 0;
@@ -13,16 +13,9 @@ exports.decorateConfig = (config) => {
     }
     .tabs_list {
       margin-left: 0;
-      padding-left: 0;
-    }
-    .tabs_list::before {
-      display: none;
-    }
-    .tab_tab::after {
-      display: none;
     }
   `
-  var defaultCSS = `
+  const defaultCSS = `
     .header_windowHeader {
       display: none;
     }
@@ -32,7 +25,7 @@ exports.decorateConfig = (config) => {
     .tabs_list {
       padding-left: 0;
     }
-    .tabs_list::before {
+    .tabs_list:before {
       display: none;
     }
     .terms_terms {
@@ -41,7 +34,7 @@ exports.decorateConfig = (config) => {
     .terms_termsShifted {
       margin-top: 34px;
     }
-    .tab_tab::after {
+    .tab_tab:after {
       display: none;
     }
   `

--- a/index.js
+++ b/index.js
@@ -13,6 +13,10 @@ exports.decorateConfig = (config) => {
     }
     .tabs_list {
       margin-left: 0;
+      padding-left: 0;
+    }
+    .tabs_list::before {
+      display: none;
     }
   `
   var defaultCSS = `
@@ -21,6 +25,12 @@ exports.decorateConfig = (config) => {
     }
     .tabs_nav {
       top: 0;
+    }
+    .tabs_list {
+      padding-left: 0;
+    }
+    .tabs_list::before {
+      display: none;
     }
     .terms_terms {
       margin-top: 0;

--- a/index.js
+++ b/index.js
@@ -18,6 +18,9 @@ exports.decorateConfig = (config) => {
     .tabs_list::before {
       display: none;
     }
+    .tab_tab::after {
+      display: none;
+    }
   `
   var defaultCSS = `
     .header_windowHeader {
@@ -37,6 +40,9 @@ exports.decorateConfig = (config) => {
     }
     .terms_termsShifted {
       margin-top: 34px;
+    }
+    .tab_tab::after {
+      display: none;
     }
   `
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperminimal",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Removes the window header from Hyper terminal for more space and less distraction.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- remove space in left of tab bar, as we don’t show any window buttons on macOS anymore
- remove extra color highlight bar to left of tab. The blue bar was a bit much especially because it distracted from the title in the center of the tab.

@rmurai0610 @net @henrikdahl please review :)