### PR TITLE
remove left border of first tab

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,8 +14,9 @@ exports.decorateConfig = (config) => {
     .tabs_list {
       margin-left: 0;
     }
-    .tab_first {
+    .tab_tab:first-of-type {
       border-left-width: 0;
+      padding-left: 1px;
     }
   `
   const defaultCSS = `

--- a/index.js
+++ b/index.js
@@ -14,6 +14,9 @@ exports.decorateConfig = (config) => {
     .tabs_list {
       margin-left: 0;
     }
+    .tab_first {
+      border-left-width: 0;
+    }
   `
   const defaultCSS = `
     .header_windowHeader {
@@ -27,6 +30,9 @@ exports.decorateConfig = (config) => {
     }
     .tabs_list:before {
       display: none;
+    }
+    .tab_first {
+      border-left-width: 0;
     }
     .terms_terms {
       margin-top: 0;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperminimal",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Removes the window header from Hyper terminal for more space and less distraction.",
   "main": "index.js",
   "scripts": {
@@ -13,7 +13,9 @@
   "keywords": [
     "hyper",
     "hyperterm",
-    "design"
+    "design",
+    "clean",
+    "minimal"
   ],
   "author": "Jan-Christoph Borchardt <hey@jancborchardt.net> (http://jancborchardt.net)",
   "license": "MIT",

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 **Removes the window header from [Hyper terminal](https://hyper.is) for more space and less distraction.**
 
-Before & after:
+Before & after, minimal & clean interface:
 
 ![](hyperminimal.png)
 


### PR DESCRIPTION
Note the left border on the first tab, slight grey bar:
![capture du 2017-01-18 16-50-12](https://cloud.githubusercontent.com/assets/925062/22071056/40113664-dd9e-11e6-8151-b8e74840d4c0.png)
Fixed with this:
![capture du 2017-01-18 16-48-59](https://cloud.githubusercontent.com/assets/925062/22071073/49361318-dd9e-11e6-8b15-4d27fb2644aa.png)


(Shout-out to @bramkok for reminding me that this was an issue, seen in https://github.com/albinekb/hyperclean/pull/3)

