### PR TITLE
MacOS: fix text selection in the first row

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,10 +67,13 @@ exports.getTabsProps = (parentProps, props) => {
     var classTermsList = document.getElementsByClassName('terms_terms')
     if (classTermsList.length > 0) {
       var classTerms = classTermsList[0]
+      var header = document.getElementsByClassName('header_header')[0]
       if (props.tabs.length <= 1) {
-        classTerms.setAttribute('style', 'margin-top: 0')
+        classTerms.style.marginTop = 0
+        header.style.visibility = 'hidden'
       } else {
-        classTerms.setAttribute('style', '')
+        classTerms.style.marginTop = ''
+        header.style.visibility = ''
       }
     }
   }


### PR DESCRIPTION
Previously, it was not possible to start selecting text in the first terminal row as the header was still overlaying it.

I'm testing with [Hyper 2.0.4 (pre-release)](https://github.com/zeit/hyper/releases), but I believe it should work just fine with the current stable release as well.